### PR TITLE
Implement point serialization with compression

### DIFF
--- a/python/zksnake/ecc.py
+++ b/python/zksnake/ecc.py
@@ -45,7 +45,12 @@ class EllipticCurve:
     def pairing(self, a, b):
         return self.curve.pairing(a, b)
 
-    def multi_pairing(self, a, b):
+    def multi_pairing(self, a: list, b: list):
+        """
+        Perform pairing of a[i] and b[i] in batch
+        and compute sum of the results
+        """
+        assert len(a) == len(b), "Length of a and b must be equal"
         return self.curve.multi_pairing(a, b)
 
     def batch_mul(self, g, s):
@@ -88,7 +93,23 @@ class EllipticCurve:
         else:
             raise TypeError(f"Invalid curve type: {g[0]}")
 
-    def __call__(self, x, y, z=1):
+    def from_hex(self, hexstring: str):
+        """
+        Construct Elliptic curve point from serialized hexstring
+        """
+        b = bytes.fromhex(hexstring)
+        n = CurvePointSize[self.name].value
+
+        if len(hexstring) == n:
+            return self.curve.PointG1.from_bytes(b)
+        elif len(hexstring) == n * 2:
+            return self.curve.PointG2.from_bytes(b)
+        else:
+            raise ValueError(
+                f"Hexstring size of {n} or {n*2} expected, got {len(hexstring)}"
+            )
+
+    def __call__(self, x, y):
 
         if isinstance(x, (tuple, list)) and isinstance(y, (tuple, list)):
             return self.curve.PointG2(x[0], x[1], y[0], y[1])

--- a/python/zksnake/groth16/verifier.py
+++ b/python/zksnake/groth16/verifier.py
@@ -1,17 +1,18 @@
 """Verification module of Groth16 protocol"""
 
-from ..ecc import EllipticCurve
+from ..ecc import EllipticCurve, CurvePointSize
 from .prover import Proof
+from ..utils import split_list
 
 
 class VerifyingKey:
     def __init__(
         self,
-        alpha_G1,
-        beta_G2,
-        gamma_G2,
-        delta_G2,
-        IC,
+        alpha_G1,  # vk_alpha_1
+        beta_G2,  # vk_beta_2
+        gamma_G2,  # vk_gamma_2
+        delta_G2,  # vk_delta_2
+        IC,  # ic
     ):
         self.alpha_1 = alpha_G1
         self.beta_2 = beta_G2
@@ -19,11 +20,50 @@ class VerifyingKey:
         self.delta_2 = delta_G2
         self.ic = IC
 
-    def from_hex(self, s: str):
-        raise NotImplementedError()
+    @classmethod
+    def from_hex(cls, s: str, crv="BN254"):
+        """Construct VerifyingKey from hexstring"""
+        E = EllipticCurve(crv)
+
+        n = CurvePointSize[crv].value
+
+        assert len(s) >= n * 7, "Invalid verifying key length"
+
+        fixed_blocks = split_list(s[: n * 7], n)
+        dynamic_blocks = s[n * 7 :]
+
+        alpha_x = fixed_blocks[0]
+        beta_x = fixed_blocks[1] + fixed_blocks[2]
+        gamma_x = fixed_blocks[3] + fixed_blocks[4]
+        delta_x = fixed_blocks[5] + fixed_blocks[6]
+
+        ic = []
+        dynamic_blocks = dynamic_blocks[16:]  # skip length header
+        dynamic_blocks = split_list(dynamic_blocks, n)
+        for block in dynamic_blocks:
+            ic.append(E.from_hex(block))
+
+        alpha_1 = E.from_hex(alpha_x)
+        beta_2 = E.from_hex(beta_x)
+        gamma_2 = E.from_hex(gamma_x)
+        delta_2 = E.from_hex(delta_x)
+
+        return VerifyingKey(alpha_1, beta_2, gamma_2, delta_2, ic)
 
     def to_hex(self) -> str:
-        raise NotImplementedError()
+        """Return hex representation of the VerifyingKey"""
+        s = (
+            self.alpha_1.to_hex()
+            + self.beta_2.to_hex()
+            + self.gamma_2.to_hex()
+            + self.delta_2.to_hex()
+        )
+
+        s += int.to_bytes(len(self.ic), 8, "little").hex()
+        for ic in self.ic:
+            s += ic.to_hex()
+
+        return s
 
 
 class Verifier:

--- a/python/zksnake/utils.py
+++ b/python/zksnake/utils.py
@@ -18,6 +18,11 @@ def get_n_jobs():
         return -1
 
 
+def split_list(data, n):
+    """Split data into n chunks"""
+    return [data[i : i + n] for i in range(0, len(data), n)]
+
+
 class Timer:
     def __init__(self, name):
         self.start_time = 0

--- a/src/bls12_381/curve.rs
+++ b/src/bls12_381/curve.rs
@@ -6,7 +6,7 @@ use ark_ec::{
 use ark_ff::{QuadExtField, Zero};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use num_bigint::BigUint;
-use pyo3::{exceptions::PyValueError, prelude::*};
+use pyo3::{exceptions::PyValueError, prelude::*, types::PyType};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 #[pyclass]
@@ -95,6 +95,33 @@ impl PointG1 {
 
     pub fn is_zero(&self) -> PyResult<bool> {
         Ok(self.point.eq(&G1Affine::identity()))
+    }
+
+    pub fn to_hex(&self) -> PyResult<String> {
+        let mut b = Vec::new();
+        let _ = self.point.serialize_compressed(&mut b);
+        let hex_string: String = b.iter().map(|byte| format!("{:02x}", byte)).collect();
+        Ok(hex_string)
+    }
+
+    pub fn to_bytes(&self) -> PyResult<Vec<u8>> {
+        let mut b = Vec::new();
+        let _ = self.point.serialize_compressed(&mut b);
+
+        Ok(b)
+    }
+
+    #[classmethod]
+    pub fn from_bytes(_cls: &PyType, hex: Vec<u8>) -> PyResult<Self> {
+        match G1Affine::deserialize_compressed(&*hex) {
+            Err(e) => Err(PyValueError::new_err(format!(
+                "Cannot deserialize point: {}",
+                e.to_string()
+            ))),
+            Ok(point) => Ok(PointG1 {
+                point: point.into(),
+            }),
+        }
     }
 }
 
@@ -193,6 +220,33 @@ impl PointG2 {
 
     pub fn is_zero(&self) -> PyResult<bool> {
         Ok(self.point.eq(&G2Affine::identity()))
+    }
+
+    pub fn to_hex(&self) -> PyResult<String> {
+        let mut b = Vec::new();
+        let _ = self.point.serialize_compressed(&mut b);
+        let hex_string: String = b.iter().map(|byte| format!("{:02x}", byte)).collect();
+        Ok(hex_string)
+    }
+
+    pub fn to_bytes(&self) -> PyResult<Vec<u8>> {
+        let mut b = Vec::new();
+        let _ = self.point.serialize_compressed(&mut b);
+
+        Ok(b)
+    }
+
+    #[classmethod]
+    pub fn from_bytes(_cls: &PyType, hex: Vec<u8>) -> PyResult<Self> {
+        match G2Affine::deserialize_compressed(&*hex) {
+            Err(e) => Err(PyValueError::new_err(format!(
+                "Cannot deserialize point: {}",
+                e.to_string()
+            ))),
+            Ok(point) => Ok(PointG2 {
+                point: point.into(),
+            }),
+        }
     }
 }
 

--- a/src/bn254/curve.rs
+++ b/src/bn254/curve.rs
@@ -6,7 +6,7 @@ use ark_ec::{
 use ark_ff::{QuadExtField, Zero};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use num_bigint::BigUint;
-use pyo3::{exceptions::PyValueError, prelude::*};
+use pyo3::{exceptions::PyValueError, prelude::*, types::PyType};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 #[pyclass]
@@ -102,6 +102,33 @@ impl PointG1 {
 
     pub fn is_zero(&self) -> PyResult<bool> {
         Ok(self.point.eq(&G1Affine::identity()))
+    }
+
+    pub fn to_hex(&self) -> PyResult<String> {
+        let mut b = Vec::new();
+        let _ = self.point.serialize_compressed(&mut b);
+        let hex_string: String = b.iter().map(|byte| format!("{:02x}", byte)).collect();
+        Ok(hex_string)
+    }
+
+    pub fn to_bytes(&self) -> PyResult<Vec<u8>> {
+        let mut b = Vec::new();
+        let _ = self.point.serialize_compressed(&mut b);
+
+        Ok(b)
+    }
+
+    #[classmethod]
+    pub fn from_bytes(_cls: &PyType, hex: Vec<u8>) -> PyResult<Self> {
+        match G1Affine::deserialize_compressed(&*hex) {
+            Err(e) => Err(PyValueError::new_err(format!(
+                "Cannot deserialize point: {}",
+                e.to_string()
+            ))),
+            Ok(point) => Ok(PointG1 {
+                point: point.into(),
+            }),
+        }
     }
 }
 
@@ -207,6 +234,33 @@ impl PointG2 {
 
     pub fn is_zero(&self) -> PyResult<bool> {
         Ok(self.point.eq(&G2Affine::identity()))
+    }
+
+    pub fn to_hex(&self) -> PyResult<String> {
+        let mut b = Vec::new();
+        let _ = self.point.serialize_compressed(&mut b);
+        let hex_string: String = b.iter().map(|byte| format!("{:02x}", byte)).collect();
+        Ok(hex_string)
+    }
+
+    pub fn to_bytes(&self) -> PyResult<Vec<u8>> {
+        let mut b = Vec::new();
+        let _ = self.point.serialize_compressed(&mut b);
+
+        Ok(b)
+    }
+
+    #[classmethod]
+    pub fn from_bytes(_cls: &PyType, hex: Vec<u8>) -> PyResult<Self> {
+        match G2Affine::deserialize_compressed(&*hex) {
+            Err(e) => Err(PyValueError::new_err(format!(
+                "Cannot deserialize point: {}",
+                e.to_string()
+            ))),
+            Ok(point) => Ok(PointG2 {
+                point: point.into(),
+            }),
+        }
     }
 }
 

--- a/tests/test_groth16.py
+++ b/tests/test_groth16.py
@@ -3,7 +3,7 @@ import pytest
 from zksnake.ecc import EllipticCurve
 from zksnake.symbolic import Symbol
 from zksnake.r1cs import ConstraintSystem
-from zksnake.groth16 import Prover, Proof, Setup, Verifier
+from zksnake.groth16 import Prover, Proof, ProvingKey, Setup, Verifier, VerifyingKey
 
 
 @pytest.fixture
@@ -41,6 +41,26 @@ def qap_data_bls12_381():
     qap = cs.compile()
 
     return qap, (pub, priv)
+
+
+@pytest.fixture
+def trusted_setup_bn254(qap_data_bn254):
+    qap, _ = qap_data_bn254
+
+    setup = Setup(qap)
+    pk, vk = setup.generate()
+
+    return pk, vk
+
+
+@pytest.fixture
+def trusted_setup_bls12_381(qap_data_bls12_381):
+    qap, _ = qap_data_bls12_381
+
+    setup = Setup(qap, "BLS12_381")
+    pk, vk = setup.generate()
+
+    return pk, vk
 
 
 def test_groth16_bn254(qap_data_bn254):
@@ -170,3 +190,27 @@ def test_proof_serialization_bls12_381():
     proof2 = Proof.from_hex(hex_proof, "BLS12_381")
 
     assert str(proof1) == str(proof2)
+
+
+def test_key_serialization_bn254(trusted_setup_bn254):
+    pk, vk = trusted_setup_bn254
+
+    pk_bytes = pk.to_bytes()
+    pk2 = ProvingKey.from_bytes(pk_bytes, crv="BN254")
+    assert pk_bytes == pk2.to_bytes()
+
+    vk_hex = vk.to_hex()
+    vk2 = VerifyingKey.from_hex(vk_hex, crv="BN254")
+    assert vk_hex == vk2.to_hex()
+
+
+def test_key_serialization_bls12_381(trusted_setup_bls12_381):
+    pk, vk = trusted_setup_bls12_381
+
+    pk_bytes = pk.to_bytes()
+    pk2 = ProvingKey.from_bytes(pk_bytes, crv="BLS12_381")
+    assert pk_bytes == pk2.to_bytes()
+
+    vk_hex = vk.to_hex()
+    vk2 = VerifyingKey.from_hex(vk_hex, crv="BLS12_381")
+    assert vk_hex == vk2.to_hex()


### PR DESCRIPTION
closes #1 

serialization protocol used arkworks method where `x` point encoded to little-endian bytes with additional parity bit to detect whether the point is positive or negative.

`Proof` and `VerifyingKey` serialization is now compatible with arkworks while `ProvingKey` is not compatible yet due to some different key elements are not used.